### PR TITLE
Workaround with request

### DIFF
--- a/soliket/tests/test_bandpass.py
+++ b/soliket/tests/test_bandpass.py
@@ -1,10 +1,8 @@
 import numpy as np
 
 from cobaya.model import get_model
-from cobaya.tools import resolve_packages_path
 from ..constants import T_CMB, h_Planck, k_Boltzmann
 
-packages_path = resolve_packages_path()
 
 info = {"params": {
     "bandint_shift_LAT_93": 0.0,
@@ -111,12 +109,12 @@ def test_bandpass_top_hat():
     assert np.allclose(bandint_freqs, bandpass)
 
 
-def test_bandpass_external_file():
+def test_bandpass_external_file(request):
     from soliket.bandpass import BandPass
     import os
 
-    filepath = os.path.join(packages_path,
-                            "../../../soliket/tests/data/")
+    filepath = os.path.join(request.config.rootdir,
+                            "soliket/tests/data/")
     # now testing reading from external file
     info["theory"].update({
         "bandpass": {"external": BandPass,

--- a/soliket/tests/test_cash.py
+++ b/soliket/tests/test_cash.py
@@ -2,9 +2,6 @@ import numpy as np
 
 from soliket.cash import CashCData
 from cobaya.theory import Theory
-from cobaya.tools import resolve_packages_path
-
-packages_path = resolve_packages_path()
 
 
 class cash_theory_calculator(Theory):
@@ -33,21 +30,21 @@ def test_cash_read_data(request):
     import os
     from soliket.cash import CashCLikelihood
 
-    cash_data_path = os.path.join(packages_path,
-            "../../../soliket/tests/data/cash_data.txt")
+    cash_data_path = os.path.join(request.config.rootdir,
+            "soliket/tests/data/cash_data.txt")
 
     cash_lkl = CashCLikelihood({"datapath": cash_data_path})
     cash_data = cash_lkl._get_data()
     assert np.allclose(cash_data[1], np.arange(20))
 
 
-def test_cash_logp():
+def test_cash_logp(request):
     import os
     from soliket.cash import CashCLikelihood
 
     params = {"cash_test_logp": 20}
-    cash_data_path = os.path.join(packages_path,
-            "../../../soliket/tests/data/cash_data.txt")
+    cash_data_path = os.path.join(request.config.rootdir,
+            "soliket/tests/data/cash_data.txt")
 
     cash_lkl = CashCLikelihood({"datapath": cash_data_path})
     cash_logp = cash_lkl.logp(**params)

--- a/soliket/tests/test_cross_correlation.py
+++ b/soliket/tests/test_cross_correlation.py
@@ -2,10 +2,7 @@ import numpy as np
 import os
 from soliket.ccl import CCL
 from cobaya.model import get_model
-from cobaya.tools import resolve_packages_path
 
-packages_path = resolve_packages_path()
-packages_path = os.path.join(packages_path, "../../../")
 
 gammakappa_sacc_file = 'soliket/tests/data/des_s-act_kappa.toy-sim.sacc.fits'
 gkappa_sacc_file = 'soliket/tests/data/gc_cmass-actdr4_kappa.sacc.fits'
@@ -39,7 +36,7 @@ def test_shearkappa_import():
     from soliket.cross_correlation import ShearKappaLikelihood # noqa F401
 
 
-def test_galaxykappa_model():
+def test_galaxykappa_model(request):
 
     from soliket.cross_correlation import GalaxyKappaLikelihood
 
@@ -48,13 +45,13 @@ def test_galaxykappa_model():
 
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
-                                  "datapath": os.path.join(packages_path,
+                                  "datapath": os.path.join(request.config.rootdir,
                                                            gkappa_sacc_file)}}
 
     model = get_model(info) # noqa F841
 
 
-def test_shearkappa_model():
+def test_shearkappa_model(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
@@ -64,13 +61,13 @@ def test_shearkappa_model():
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file)}}
 
     model = get_model(info) # noqa F841
 
 
-def test_galaxykappa_like():
+def test_galaxykappa_like(request):
 
     from soliket.cross_correlation import GalaxyKappaLikelihood
 
@@ -79,7 +76,7 @@ def test_galaxykappa_like():
 
     info["likelihood"] = {
         "GalaxyKappaLikelihood": {"external": GalaxyKappaLikelihood,
-                                  "datapath": os.path.join(packages_path,
+                                  "datapath": os.path.join(request.config.rootdir,
                                                            gkappa_sacc_file),
                                   "use_spectra": [('gc_cmass', 'ck_actdr4')]}}
 
@@ -90,11 +87,11 @@ def test_galaxykappa_like():
     assert np.isclose(loglikes[0], 174.013, atol=0.2, rtol=0.0)
 
 
-def test_shearkappa_like():
+def test_shearkappa_like(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    rootdir = packages_path
+    rootdir = request.config.rootdir
 
     cs82_file = "soliket/tests/data/cs82_gs-planck_kappa_binned.sim.sacc.fits"
     test_datapath = os.path.join(rootdir, cs82_file)
@@ -122,12 +119,12 @@ def test_shearkappa_like():
     assert np.isclose(loglikes, 637.64473666)
 
 
-def test_shearkappa_tracerselect():
+def test_shearkappa_tracerselect(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
     import copy
 
-    rootdir = packages_path
+    rootdir = request.config.rootdir
 
     test_datapath = os.path.join(rootdir, gammakappa_sacc_file)
 
@@ -174,11 +171,11 @@ def test_shearkappa_tracerselect():
                        lhood_twobin.data.y)
 
 
-def test_shearkappa_hartlap():
+def test_shearkappa_hartlap(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
-    rootdir = packages_path
+    rootdir = request.config.rootdir
 
     cs82_file = "soliket/tests/data/cs82_gs-planck_kappa_binned.sim.sacc.fits"
     test_datapath = os.path.join(rootdir, cs82_file)
@@ -213,13 +210,13 @@ def test_shearkappa_hartlap():
                       rtol=1.e-5, atol=1.e-5)
 
 
-def test_shearkappa_deltaz():
+def test_shearkappa_deltaz(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file),
                            "z_nuisance_mode": "deltaz"}}
 
@@ -229,13 +226,13 @@ def test_shearkappa_deltaz():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_m():
+def test_shearkappa_m(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file),
                            "m_nuisance_mode": True}}
 
@@ -245,13 +242,13 @@ def test_shearkappa_m():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_nla_noevo():
+def test_shearkappa_ia_nla_noevo(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file),
                            "ia_mode": 'nla-noevo'}}
 
@@ -261,13 +258,13 @@ def test_shearkappa_ia_nla_noevo():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_nla():
+def test_shearkappa_ia_nla(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file),
                            "ia_mode": 'nla'}}
 
@@ -279,13 +276,13 @@ def test_shearkappa_ia_nla():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_ia_perbin():
+def test_shearkappa_ia_perbin(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file),
                            "ia_mode": 'nla-perbin'}}
 
@@ -295,13 +292,13 @@ def test_shearkappa_ia_perbin():
     assert np.isfinite(loglikes)
 
 
-def test_shearkappa_hmcode():
+def test_shearkappa_hmcode(request):
 
     from soliket.cross_correlation import ShearKappaLikelihood
 
     info["likelihood"] = {"ShearKappaLikelihood":
                           {"external": ShearKappaLikelihood,
-                           "datapath": os.path.join(packages_path,
+                           "datapath": os.path.join(request.config.rootdir,
                                                     gammakappa_sacc_file)}}
     info["theory"] = {"camb": {'extra_args': {'halofit_version': 'mead2020_feedback',
                                               'HMCode_logT_AGN': 7.8}},

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ extras =
 commands =
     pip freeze
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native --no-set-global
-    !cov: pytest -v --pyargs soliket {posargs}
-    cov: pytest -v --pyargs soliket --cov soliket --cov-report=xml --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov: pytest -v --rootdir={changedir}/../../ --pyargs soliket {posargs}
+    cov: pytest -v --rootdir={changedir}/../../ --pyargs soliket --cov soliket --cov-report=xml --cov-config={toxinidir}/setup.cfg {posargs}
 
 [testenv:codestyle]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ extras =
 commands =
     pip freeze
     all: cobaya-install planck_2018_highl_plik.TTTEEE_lite_native --no-set-global
-    !cov: pytest -v --rootdir={changedir}/../../ --pyargs soliket {posargs}
-    cov: pytest -v --rootdir={changedir}/../../ --pyargs soliket --cov soliket --cov-report=xml --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov: pytest -v --rootdir={toxinidir} --pyargs soliket {posargs}
+    cov: pytest -v --rootdir={toxinidir} --pyargs soliket --cov soliket --cov-report=xml --cov-config={toxinidir}/setup.cfg {posargs}
 
 [testenv:codestyle]
 skip_install = true


### PR DESCRIPTION
I reverted the change on the request to find the path to data, while I forced `rootdir` to point toward the path of `tox.ini`