### PR TITLE
Upgrade syntax to Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "Likelihood and Theory codes for the Simons Observatory."
 readme = "README.rst"
-requires-python = ">=3.9,<=3.11"
+requires-python = ">=3.9,<3.12"
 license = { text = "MIT" }
 dependencies = [
     "requests",

--- a/soliket-tests.yml
+++ b/soliket-tests.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.9,<=3.11
+  - python>=3.9,<3.12
   - pip
   - pytest
   - pytest-cov

--- a/soliket/bias/bias.py
+++ b/soliket/bias/bias.py
@@ -56,8 +56,8 @@ class Bias(Theory):
 
         self.nonlinear = self.nonlinear or options.get("nonlinear", False)
         self._var_pairs.update(
-            set((x, y) for x, y in
-                options.get("vars_pairs", [("delta_tot", "delta_tot")])))
+            {(x, y) for x, y in
+                options.get("vars_pairs", [("delta_tot", "delta_tot")])})
 
         needs["Pk_grid"] = {
             "vars_pairs": self._var_pairs or [("delta_tot", "delta_tot")],

--- a/soliket/ccl/ccl.py
+++ b/soliket/ccl/ccl.py
@@ -79,7 +79,7 @@ the likelihood.
 # https://cobaya.readthedocs.io/en/devel/theories_and_dependencies.html
 
 import numpy as np
-from typing import Sequence
+from collections.abc import Sequence
 from cobaya.theory import Theory
 from cobaya.tools import LoggedError
 
@@ -132,8 +132,8 @@ class CCL(Theory):
             # CCL currently only supports ('delta_tot', 'delta_tot'), but call allow
             # general as placeholder
             self._var_pairs.update(
-                set((x, y) for x, y in
-                    options.get('vars_pairs', [('delta_tot', 'delta_tot')])))
+                {(x, y) for x, y in
+                    options.get('vars_pairs', [('delta_tot', 'delta_tot')])})
 
             needs['Pk_grid'] = {
                 'vars_pairs': self._var_pairs or [('delta_tot', 'delta_tot')],

--- a/soliket/clusters/tinker.py
+++ b/soliket/clusters/tinker.py
@@ -37,7 +37,7 @@ def tinker_params_spline(delta, z=None):
             x = np.hstack((D, D[-1] + 3.))
             y = np.hstack((y, np.polyval(p, x[-1])))
             tinker_splines.append(iuSpline(x, y, k=2))
-    A0, a0, b0, c0 = [ts(np.log(delta)) for ts in tinker_splines]
+    A0, a0, b0, c0 = (ts(np.log(delta)) for ts in tinker_splines)
     if z is None:
         return A0, a0, b0, c0
 
@@ -53,8 +53,8 @@ def tinker_params_spline(delta, z=None):
 def tinker_params_analytic(delta, z=None):
     alpha = None
     if np.asarray(delta).ndim == 0:  # scalar delta.
-        A0, a0, b0, c0 = [p[0] for p in
-                          tinker_params(np.array([delta]), z=None)]
+        A0, a0, b0, c0 = (p[0] for p in
+                          tinker_params(np.array([delta]), z=None))
         if z is not None:
             if delta < 75.:
                 alpha = 1.

--- a/soliket/cosmopower/cosmopower.py
+++ b/soliket/cosmopower/cosmopower.py
@@ -91,7 +91,7 @@ temperature. See the :func:`~soliket.cosmopower.CosmoPower.ell_factor` and
 information on how SOLikeT infers these values.
 """
 import os
-from typing import Iterable, Tuple
+from collections.abc import Iterable
 
 import numpy as np
 from cobaya.log import LoggedError
@@ -116,7 +116,7 @@ class CosmoPower(BoltzmannBase):
             raise LoggedError("No network settings were provided.")
 
         self.networks = {}
-        self.all_parameters = set([])
+        self.all_parameters = set()
 
         for spectype in self.network_settings:
             netdata = {}
@@ -282,7 +282,7 @@ class CosmoPower(BoltzmannBase):
     def get_can_support_parameters(self) -> Iterable[str]:
         return self.all_parameters
 
-    def get_requirements(self) -> Iterable[Tuple[str, str]]:
+    def get_requirements(self) -> Iterable[tuple[str, str]]:
         requirements = []
         for k in self.all_parameters:
             if k in self.renames.values():
@@ -364,7 +364,7 @@ class CosmoPowerDerived(Theory):
     def get_can_support_parameters(self) -> Iterable[str]:
         return self.input_parameters
 
-    def get_requirements(self) -> Iterable[Tuple[str, str]]:
+    def get_requirements(self) -> Iterable[tuple[str, str]]:
         requirements = []
         for k in self.input_parameters:
             if k in self.renames.values():
@@ -378,5 +378,5 @@ class CosmoPowerDerived(Theory):
         return requirements
 
     def get_can_provide(self) -> Iterable[str]:
-        return set([par for par in self.derived_parameters
-                    if (len(par) > 0 and not par == "_")])
+        return {par for par in self.derived_parameters
+                    if (len(par) > 0 and not par == "_")}

--- a/soliket/cross_correlation/cross_correlation.py
+++ b/soliket/cross_correlation/cross_correlation.py
@@ -41,7 +41,7 @@ class CrossCorrelationLikelihood(GaussianLikelihood):
             if (self.sacc_data.tracers[tracer_comb[0]].quantity ==
                     self.sacc_data.tracers[tracer_comb[1]].quantity):
                 raise LoggedError(self.log,
-                                  'You have tried to use {0} to calculate an \
+                                  'You have tried to use {} to calculate an \
                                    autocorrelation, but it is a cross-correlation \
                                    likelihood. Please check your tracer selection in the \
                                    ini file.'.format(self.__class__.__name__))
@@ -49,8 +49,8 @@ class CrossCorrelationLikelihood(GaussianLikelihood):
             for tracer in tracer_comb:
                 if self.sacc_data.tracers[tracer].quantity not in self._allowable_tracers:
                     raise LoggedError(self.log,
-                                      'You have tried to use a {0} tracer in \
-                                       {1}, which only allows {2}. Please check your \
+                                      'You have tried to use a {} tracer in \
+                                       {}, which only allows {}. Please check your \
                                        tracer selection in the ini file.\
                                        '.format(self.sacc_data.tracers[tracer].quantity,
                                                 self.__class__.__name__,
@@ -59,7 +59,7 @@ class CrossCorrelationLikelihood(GaussianLikelihood):
     def _get_nz(self, z, tracer, tracer_name, **params_values):
 
         if self.z_nuisance_mode == 'deltaz':
-            bias = params_values['{}_deltaz'.format(tracer_name)]
+            bias = params_values[f'{tracer_name}_deltaz']
             nz_biased = tracer.get_dndz(z - bias)
 
         # nz_biased /= np.trapezoid(nz_biased, z)
@@ -206,7 +206,7 @@ class ShearKappaLikelihood(CrossCorrelationLikelihood):
 
                     ia_z = (z_tracer1, A_IA * ((1 + z_tracer1) / (1 + z0_IA)) ** eta_IA)
                 elif self.ia_mode == 'nla-perbin':
-                    A_IA = params_values['{}_A_IA'.format(sheartracer_name)]
+                    A_IA = params_values[f'{sheartracer_name}_A_IA']
                     ia_z = (z_tracer1, A_IA * np.ones_like(z_tracer1))
                 elif self.ia_mode == 'nla-noevo':
                     A_IA = params_values['A_IA']
@@ -246,7 +246,7 @@ class ShearKappaLikelihood(CrossCorrelationLikelihood):
 
                     ia_z = (z_tracer2, A_IA * ((1 + z_tracer2) / (1 + z0_IA)) ** eta_IA)
                 elif self.ia_mode == 'nla-perbin':
-                    A_IA = params_values['{}_A_IA'.format(sheartracer_name)]
+                    A_IA = params_values[f'{sheartracer_name}_A_IA']
                     ia_z = (z_tracer2, A_IA * np.ones_like(z_tracer2))
                 elif self.ia_mode == 'nla-noevo':
                     A_IA = params_values['A_IA']
@@ -278,7 +278,7 @@ class ShearKappaLikelihood(CrossCorrelationLikelihood):
                 # note this allows wrong calculation, as we can do
                 # shear x shear if the spectra are in the sacc
                 # but then we would want (1 + m1) * (1 + m2)
-                m_bias = params_values['{}_m'.format(sheartracer_name)]
+                m_bias = params_values[f'{sheartracer_name}_m']
                 cl_unbinned = (1 + m_bias) * cl_unbinned
 
             cl_binned = np.dot(w_bins, cl_unbinned)

--- a/soliket/gaussian/gaussian.py
+++ b/soliket/gaussian/gaussian.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from cobaya.input import merge_info
@@ -12,9 +12,9 @@ from soliket.gaussian.gaussian_data import GaussianData, MultiGaussianData
 
 class GaussianLikelihood(Likelihood):
     name: str = "Gaussian"
-    datapath: Optional[str] = None
-    covpath: Optional[str] = None
-    ncovsims: Optional[int] = None
+    datapath: str | None = None
+    covpath: str | None = None
+    ncovsims: int | None = None
 
     def initialize(self):
         x, y = self._get_data()
@@ -52,9 +52,9 @@ class CrossCov(dict):
 
 
 class MultiGaussianLikelihood(GaussianLikelihood):
-    components: Optional[Sequence] = None
-    options: Optional[Sequence] = None
-    cross_cov_path: Optional[str] = None
+    components: Sequence | None = None
+    options: Sequence | None = None
+    cross_cov_path: str | None = None
 
     def __init__(self, info=empty_dict, **kwargs):
 

--- a/soliket/gaussian/gaussian_data.py
+++ b/soliket/gaussian/gaussian_data.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
 import numpy as np
 from cobaya.functions import chi_squared
 
@@ -12,12 +12,12 @@ class GaussianData:
     y: np.ndarray  # data point values
     cov: np.ndarray  # covariance matrix
     inv_cov: np.ndarray  # inverse covariance matrix
-    ncovsims: Optional[int]  # number of simulations used to estimate covariance
+    ncovsims: int | None  # number of simulations used to estimate covariance
 
     _fast_chi_squared = staticmethod(chi_squared)
 
     def __init__(self, name, x: Sequence, y: Sequence[float], cov: np.ndarray,
-                 ncovsims: Optional[int] = None):
+                 ncovsims: int | None = None):
 
         self.name = str(name)
         self.ncovsims = ncovsims

--- a/soliket/halo_model/halo_model.py
+++ b/soliket/halo_model/halo_model.py
@@ -93,8 +93,8 @@ class HaloModel_pyhm(HaloModel):
 
         options = requirements.get("halo_model") or {}
         self._var_pairs.update(
-            set((x, y) for x, y in
-                options.get("vars_pairs", [("delta_tot", "delta_tot")])))
+            {(x, y) for x, y in
+                options.get("vars_pairs", [("delta_tot", "delta_tot")])})
 
         self.kmax = max(self.kmax, options.get("kmax", self.kmax))
         self.z = np.unique(np.concatenate(

--- a/soliket/tests/test_gaussian.py
+++ b/soliket/tests/test_gaussian.py
@@ -47,7 +47,7 @@ def test_gaussian():
 
     multi = MultiGaussianData(datalist, cross_cov)
 
-    name1, name2, name3 = [d.name for d in datalist]
+    name1, name2, name3 = (d.name for d in datalist)
     data1, data2, data3 = datalist
 
     assert (multi.cross_covs[(name1, name2)] == multi.cross_covs[(name2, name1)].T).all()

--- a/soliket/tests/test_ps.py
+++ b/soliket/tests/test_ps.py
@@ -37,7 +37,7 @@ class ToyLikelihood(PSLikelihood):
 def test_toy():
     n1, n2, n3 = [10, 20, 30]
     full_cov = make_spd_matrix(n1 + n2 + n3, random_state=1234) * 1e-1
-    full_cov += np.diag(np.ones((n1 + n2 + n3)))
+    full_cov += np.diag(np.ones(n1 + n2 + n3))
 
     cov1 = full_cov[:n1, :n1]
     cov2 = full_cov[n1: n1 + n2, n1: n1 + n2]


### PR DESCRIPTION
This PR upgrades the syntax to Python 3.10 using `pyupgrade`.

Also, this fixes a bug in the required Python version, which did not allow 3.11.X. 